### PR TITLE
Migrate source to Qt6

### DIFF
--- a/KoggerApp.pro
+++ b/KoggerApp.pro
@@ -2,6 +2,7 @@ QT += quick
 QT += widgets
 QT += network
 QT += qml
+QT += opengl openglwidgets
 
 #CONFIG += FLASHER
 #CONFIG += MOTOR # motor_control definition

--- a/LinkManager.cpp
+++ b/LinkManager.cpp
@@ -254,10 +254,10 @@ void LinkManager::importPinnedLinksFromXML()
         const QXmlStreamReader::TokenType token = xmlReader.readNext();
 
         if (token == QXmlStreamReader::StartElement) {
-            if (xmlReader.name() == "link") {
+            if (xmlReader.name().toString() == "link") {
                 Link* link = createNewLink();
 
-                while (!(xmlReader.tokenType() == QXmlStreamReader::EndElement && xmlReader.name() == "link")) {
+                while (!(xmlReader.tokenType() == QXmlStreamReader::EndElement && xmlReader.name().toString() == "link")) {
                     if (xmlReader.tokenType() == QXmlStreamReader::StartElement) {
                         if (xmlReader.name().toString() == "uuid") {
                             link->setUuid(QUuid(xmlReader.readElementText()));

--- a/QML/BottomTrackControlMenu.qml
+++ b/QML/BottomTrackControlMenu.qml
@@ -1,8 +1,8 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
-import Qt.labs.settings 1.1
+import QtQuick.Dialogs
+import Qt.labs.settings
 
 import KoggerCommon 1.0
 Item {

--- a/QML/CalcMethodTINSettings.qml
+++ b/QML/CalcMethodTINSettings.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 ColumnLayout {

--- a/QML/ChartBox.qml
+++ b/QML/ChartBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 

--- a/QML/CheckButton.qml
+++ b/QML/CheckButton.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Controls.Styles 1.4
 
 Button {
     id: control

--- a/QML/ConnectionViewer.qml
+++ b/QML/ConnectionViewer.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 ColumnLayout {
@@ -508,7 +508,7 @@ ColumnLayout {
             FileDialog {
                 id: newFileDialog
                 title: qsTr("Please choose a file")
-                folder: shortcuts.home
+                currentFolder: shortcuts.home
 
                 nameFilters: ["Logs (*.klf *.ubx *.xtf)", "Kogger log files (*.klf)", "U-blox (*.ubx)"]
 
@@ -524,7 +524,7 @@ ColumnLayout {
             }
 
             Settings {
-                property alias logFolder: newFileDialog.folder
+                property alias logFolder: newFileDialog.currentFolder
             }
         }
 
@@ -542,7 +542,7 @@ ColumnLayout {
             FileDialog {
                 id: appendFileDialog
                 title: qsTr("Please choose a file")
-                folder: shortcuts.home
+                currentFolder: shortcuts.home
 
                 nameFilters: ["Logs (*.klf *.ubx *.xtf)", "Kogger log files (*.klf)", "U-blox (*.ubx)"]
 
@@ -559,7 +559,7 @@ ColumnLayout {
             }
 
             Settings {
-                property alias logFolder: appendFileDialog.folder
+                property alias logFolder: appendFileDialog.currentFolder
             }
         }
 

--- a/QML/DatasetBox.qml
+++ b/QML/DatasetBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 

--- a/QML/DeviceItem.qml
+++ b/QML/DeviceItem.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 
@@ -202,8 +202,8 @@ ColumnLayout {
 
                 property var items: ["Off", "On"]
 
-                validator: RegExpValidator {
-                    regExp: new RegExp("(Off|On)", "i")
+                validator: RegularExpressionValidator {
+                    regularExpression: new RegExp("(Off|On)", "i")
                 }
 
                 textFromValue: function(value) {

--- a/QML/DeviceSettingsViewer.qml
+++ b/QML/DeviceSettingsViewer.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 MenuScroll {

--- a/QML/DiplaySettingsViewer.qml
+++ b/QML/DiplaySettingsViewer.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 MenuScroll {

--- a/QML/DisplaySettings.qml
+++ b/QML/DisplaySettings.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 GridLayout {
@@ -991,21 +991,19 @@ GridLayout {
                         onClicked: exportFileDialog.open()
                     }
 
-                    FileDialog {
+                    FolderDialog {
                         id: exportFileDialog
-                        folder: shortcuts.home
-                        selectExisting: true
-                        selectFolder: true
+                        currentFolder: shortcuts.home
 
                         onAccepted: {
-                            exportPathText.text = exportFileDialog.folder.toString()
+                            exportPathText.text = exportFileDialog.selectedFolder.toString()
                         }
 
                         onRejected: { }
                     }
 
                     Settings {
-                        property alias exportFolder: exportFileDialog.folder
+                        property alias exportFolder: exportFileDialog.currentFolder
                     }
 
                     Settings {

--- a/QML/DopplerBox.qml
+++ b/QML/DopplerBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 DevSettingsBox {

--- a/QML/ExportDist.qml
+++ b/QML/ExportDist.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 Item {

--- a/QML/ExportSettings.qml
+++ b/QML/ExportSettings.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 MenuScroll {

--- a/QML/FactoryBox.qml
+++ b/QML/FactoryBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 DevSettingsBox {
@@ -11,7 +11,7 @@ DevSettingsBox {
         FileDialog {
             id: fileDialog
             title: qsTr("Please choose a file")
-            folder: shortcuts.home
+            currentFolder: shortcuts.home
             nameFilters: ["Upgrade files (*.bin)"]
             onAccepted: {
                 pathText.text = fileDialog.fileUrl.toString()
@@ -21,7 +21,7 @@ DevSettingsBox {
         }
 
         Settings {
-            property alias upgradeFolder: fileDialog.folder
+            property alias upgradeFolder: fileDialog.currentFolder
         }
 
     MenuBlock {

--- a/QML/FlashBox.qml
+++ b/QML/FlashBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 

--- a/QML/KoggerCommon/MenuBlockEx.qml
+++ b/QML/KoggerCommon/MenuBlockEx.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 Rectangle {

--- a/QML/MenuBlock.qml
+++ b/QML/MenuBlock.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 Rectangle {

--- a/QML/MenuButton.qml
+++ b/QML/MenuButton.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Controls.Styles 1.4
 
 Button {
     property bool active: false

--- a/QML/MotorViewer.qml
+++ b/QML/MotorViewer.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 ColumnLayout {
@@ -276,7 +276,7 @@ ColumnLayout {
             FileDialog {
                 id: newFileDialog
                 title: "Please choose a CSV file"
-                folder: shortcuts.home
+                currentFolder: shortcuts.home
 
                 nameFilters: ["CSV (*.csv)"]
 
@@ -291,7 +291,7 @@ ColumnLayout {
             }
 
             Settings {
-                property alias logFolder: newFileDialog.folder
+                property alias logFolder: newFileDialog.currentFolder
             }
         }
 

--- a/QML/MpcFilterControlMenu.qml
+++ b/QML/MpcFilterControlMenu.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 import KoggerCommon 1.0

--- a/QML/NpdFilterControlMenu.qml
+++ b/QML/NpdFilterControlMenu.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 import KoggerCommon 1.0

--- a/QML/Plot2D.qml
+++ b/QML/Plot2D.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 import WaterFall 1.0

--- a/QML/PointGroupControlMenu.qml
+++ b/QML/PointGroupControlMenu.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 import KoggerCommon 1.0

--- a/QML/PolygonGroupControlMenu.qml
+++ b/QML/PolygonGroupControlMenu.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 import QtQuick.Controls 1.4
 

--- a/QML/RecorderBox.qml
+++ b/QML/RecorderBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 import QtQml.Models 2.15
 

--- a/QML/Scene3DToolbar.qml
+++ b/QML/Scene3DToolbar.qml
@@ -2,7 +2,7 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import Qt.labs.settings 1.1
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 
 
 ColumnLayout {

--- a/QML/SmoothMethodTriDivideSettings.qml
+++ b/QML/SmoothMethodTriDivideSettings.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 ColumnLayout {

--- a/QML/SmoothMethodUGINSettings.qml
+++ b/QML/SmoothMethodUGINSettings.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 ColumnLayout {

--- a/QML/SonarBox.qml
+++ b/QML/SonarBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 DevSettingsBox {
@@ -83,7 +83,7 @@ DevSettingsBox {
             FileDialog {
                 id: importFileDialog
                 title: qsTr("Open file")
-                selectExisting: true
+                fileMode: FileDialog.OpenFile
                 nameFilters: ["XML files (*.xml)"]
 
                 onAccepted: {
@@ -100,7 +100,7 @@ DevSettingsBox {
             FileDialog {
                 id: exportFileDialog
                 title: qsTr("Save as file")
-                selectExisting: false
+                fileMode: FileDialog.SaveFile
                 nameFilters: ["XML files (*.xml)"]
 
                 onAccepted: {

--- a/QML/SurfaceControlMenu.qml
+++ b/QML/SurfaceControlMenu.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.12
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 import KoggerCommon 1.0
 import SceneObject 1.0

--- a/QML/TitleMenuBox.qml
+++ b/QML/TitleMenuBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 RowLayout {

--- a/QML/USBLBox.qml
+++ b/QML/USBLBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 DevSettingsBox {

--- a/QML/UpgradeBox.qml
+++ b/QML/UpgradeBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import Qt.labs.settings 1.1
 
 DevSettingsBox {
@@ -12,7 +12,7 @@ DevSettingsBox {
     FileDialog {
         id: fileDialog
         title: qsTr("Please choose a file")
-        folder: shortcuts.home
+        currentFolder: shortcuts.home
         nameFilters: ["Upgrade files (*.ufw)"]
         onAccepted: {
             pathText.text = fileDialog.fileUrl.toString()
@@ -22,7 +22,7 @@ DevSettingsBox {
     }
 
     Settings {
-        property alias upgradeFolder: fileDialog.folder
+        property alias upgradeFolder: fileDialog.currentFolder
     }
 
     ColumnLayout {

--- a/QML/main.qml
+++ b/QML/main.qml
@@ -3,10 +3,11 @@ import SceneGraphRendering 1.0
 import QtQuick.Window 2.15
 import QtQuick.Layouts 1.15
 import Qt.labs.settings 1.1
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 import QtQuick.Controls 2.15
 import WaterFall 1.0
 import KoggerCommon 1.0
+import '.' as KControls
 
 
 Window  {
@@ -603,7 +604,7 @@ Window  {
         }
     }
 
-    MenuBar {
+    KControls.MenuBar {
         id:                menuBar
         objectName:        "menuBar"
         Layout.fillHeight: true

--- a/controllers/boattrackcontrolmenucontroller.h
+++ b/controllers/boattrackcontrolmenucontroller.h
@@ -5,6 +5,12 @@
 
 class BoatTrack;
 class GraphicsScene3dView;
+
+#ifndef OPAQUE_BoatTrack
+#define OPAQUE_BoatTrack
+Q_DECLARE_OPAQUE_POINTER(BoatTrack*)
+#endif
+
 class BoatTrackControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/controllers/bottomtrackcontrolmenucontroller.h
+++ b/controllers/bottomtrackcontrolmenucontroller.h
@@ -7,6 +7,12 @@
 
 class BottomTrack;
 class GraphicsScene3dView;
+
+#ifndef OPAQUE_BottomTrack
+#define OPAQUE_BottomTrack
+Q_DECLARE_OPAQUE_POINTER(BottomTrack*)
+#endif
+
 class BottomTrackControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/controllers/image_view_control_menu_controller.h
+++ b/controllers/image_view_control_menu_controller.h
@@ -4,6 +4,12 @@
 
 class ImageView;
 class GraphicsScene3dView;
+
+#ifndef OPAQUE_ImageView
+#define OPAQUE_ImageView
+Q_DECLARE_OPAQUE_POINTER(ImageView*)
+#endif
+
 class ImageViewControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/controllers/pointgroupcontrolmenucontroller.h
+++ b/controllers/pointgroupcontrolmenucontroller.h
@@ -9,6 +9,12 @@
 class GraphicsScene3dView;
 class PointGroup;
 class PointObject;
+
+#ifndef OPAQUE_PointGroup
+#define OPAQUE_PointGroup
+Q_DECLARE_OPAQUE_POINTER(PointGroup*)
+#endif
+
 class PointGroupControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/controllers/polygongroupcontrolmenucontroller.h
+++ b/controllers/polygongroupcontrolmenucontroller.h
@@ -11,6 +11,12 @@
 class PolygonGroup;
 class GraphicsScene3dView;
 class PointObject;
+
+#ifndef OPAQUE_PolygonGroup
+#define OPAQUE_PolygonGroup
+Q_DECLARE_OPAQUE_POINTER(PolygonGroup*)
+#endif
+
 class PolygonGroupControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/controllers/side_scan_view_control_menu_controller.h
+++ b/controllers/side_scan_view_control_menu_controller.h
@@ -6,6 +6,13 @@
 class Core;
 class SideScanView;
 class GraphicsScene3dView;
+
+#ifndef OPAQUE_SideScanView
+#define OPAQUE_SideScanView
+Q_DECLARE_OPAQUE_POINTER(SideScanView*)
+#endif
+
+
 class SideScanViewControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/controllers/surfacecontrolmenucontroller.h
+++ b/controllers/surfacecontrolmenucontroller.h
@@ -9,6 +9,12 @@
 
 class Surface;
 class GraphicsScene3dView;
+
+#ifndef OPAQUE_SurfaceGroup
+#define OPAQUE_SurfaceGroup
+Q_DECLARE_OPAQUE_POINTER(Surface*)
+#endif
+
 class SurfaceControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/controllers/usbl_view_control_menu_controller.h
+++ b/controllers/usbl_view_control_menu_controller.h
@@ -8,6 +8,12 @@
 
 class UsblView;
 class GraphicsScene3dView;
+
+#ifndef OPAQUE_UsblView
+#define OPAQUE_UsblView
+Q_DECLARE_OPAQUE_POINTER(UsblView*)
+#endif
+
 class UsblViewControlMenuController : public QmlComponentController
 {
     Q_OBJECT

--- a/domain/boattrack.cpp
+++ b/domain/boattrack.cpp
@@ -1,6 +1,6 @@
 #include "boattrack.h"
 
-#include <QtOpenGLExtensions/QOpenGLExtensions>
+#include <QOpenGLFunctions>
 #include <QHash>
 #include "graphicsscene3dview.h"
 #include <epochevent.h>

--- a/domain/bottomtrack.cpp
+++ b/domain/bottomtrack.cpp
@@ -4,7 +4,7 @@
 //#include <textrenderer.h> TODO
 #include <draw_utils.h>
 #include "boattrack.h"
-#include <QtOpenGLExtensions/QOpenGLExtensions>
+#include <QOpenGLFunctions>
 
 #include <QHash>
 

--- a/domain/side_scan_view.cpp
+++ b/domain/side_scan_view.cpp
@@ -78,7 +78,7 @@ void SideScanView::startUpdateDataInThread(int endIndx, int endOffset)
 
 void SideScanView::updateData(int endIndx, int endOffset, bool backgroundThread)
 {
-    std::unique_ptr<QMutexLocker> locker;
+    QMutexLocker<QMutex> locker(nullptr);
     std::function<void()> cleanFunc;
     if (backgroundThread) {
         cleanFunc = [&, this]() {
@@ -87,7 +87,7 @@ void SideScanView::updateData(int endIndx, int endOffset, bool backgroundThread)
                 emit sendStartedInThread(startedInThread_);
             }
         };
-        locker = std::make_unique<QMutexLocker>(&mutex_);
+        locker = QMutexLocker(&mutex_);
     }
 
     if (!datasetPtr_) {

--- a/main.cpp
+++ b/main.cpp
@@ -110,7 +110,11 @@ int main(int argc, char *argv[])
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
 #endif
 
+#if defined(QT_VERSION_CHECK) && (QT_VERSION_MAJOR >= 6)
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGLRhi);
+#else
     QQuickWindow::setSceneGraphBackend(QSGRendererInterface::OpenGLRhi);
+#endif
 
     QSurfaceFormat format;
     format.setSwapInterval(0);

--- a/main.cpp
+++ b/main.cpp
@@ -110,11 +110,7 @@ int main(int argc, char *argv[])
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
 #endif
 
-#if defined(QT_VERSION_CHECK) && (QT_VERSION_MAJOR >= 6)
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGLRhi);
-#else
-    QQuickWindow::setSceneGraphBackend(QSGRendererInterface::OpenGLRhi);
-#endif
 
     QSurfaceFormat format;
     format.setSwapInterval(0);

--- a/processors/surfaceprocessor.h
+++ b/processors/surfaceprocessor.h
@@ -23,6 +23,12 @@
 #include <abstractentitydatafilter.h>
 
 class BottomTrack;
+
+#ifndef OPAQUE_BottomTrack
+#define OPAQUE_BottomTrack
+Q_DECLARE_OPAQUE_POINTER(BottomTrack*)
+#endif
+
 class SurfaceProcessorTask{
     Q_GADGET
     Q_PROPERTY(BottomTrack*              bottomTrack           READ bottomTrack           CONSTANT)


### PR DESCRIPTION
### Changelog:
* Replace `setSceneGraphBackend` to `setGraphicsApi`
* Fix XML Reader complication issue under Qt6
* Update OpenGL references to Qt6 OpenGL module
* Update qml files to use new Qt6 qml modules
* Fix compilation issues with forward declarations under Qt6
* Fix improper use of `std::unique_ptr` with `QMutexLocker`
* Removed Qt5 support due to conflicting modules in Qt5 and Qt6

### Build Environment
OS: **Ubuntu 24.10**
Qt Version: **6.6.2**
GCC version: **14**

### Instructions
#### Packages required for compiling under Ubuntu:
**Qt**

- qt6-base-dev
- qt6-declarative-dev
- qt6-serialport-dev

**QML**

- qml6-module-qtquick-controls
- qml6-module-qtquick-dialogs
- qml6-module-qt-labs-settings
- qml6-module-qtquick-window
- qml6-module-qt-labs-folderlistmodel

#### Packages required for running under Ubuntu:

- qt6-base
- qt6-serialport
- qml6-module-qtquick-controls
- qml6-module-qtquick-dialogs
- qml6-module-qt-labs-settings
- qml6-module-qtquick-window
- qml6-module-qt-labs-folderlistmodel

#### How to build (Ubuntu 24.10)
Install all the packages in Ubuntu using `sudo apt install <package-name>`
Install qtcreator using `sudo apt install qtcreator`
Open KoggerApp.pro file and select Qt6 kit
Click Build

#### How to run (Ubuntu 24.10)
Install all the packages in Ubuntu using `sudo apt install <package-name>`
Download and extract the file [KoggerApp.zip](https://github.com/user-attachments/files/18040677/KoggerApp.zip)
Set executable permission. eg. `sudo chmod +x KoggerApp` or `sudo chmod 777 KoggerApp`
Run the app. eg. `./KoggerApp`
